### PR TITLE
updates for stencil.config.dev.ts

### DIFF
--- a/packages/fa-icon-chooser/package-lock.json
+++ b/packages/fa-icon-chooser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fortawesome/fa-icon-chooser",
-  "version": "0.8.0-5",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fortawesome/fa-icon-chooser",
-      "version": "0.8.0-5",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@fortawesome/fontawesome-common-types": "^6.5.2",

--- a/packages/fa-icon-chooser/package.json
+++ b/packages/fa-icon-chooser/package.json
@@ -46,7 +46,7 @@
   ],
   "scripts": {
     "build": "stencil build",
-    "start": "stencil build --dev --watch --serve",
+    "start": "stencil build --config stencil.config.dev.ts --watch --serve",
     "test": "stencil test --spec --e2e",
     "test.watch": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate",

--- a/packages/fa-icon-chooser/stencil.config.dev.ts
+++ b/packages/fa-icon-chooser/stencil.config.dev.ts
@@ -1,12 +1,16 @@
 import { Config } from '@stencil/core';
+import { config as baseConfig } from './stencil.config';
+import { join } from 'path';
 
 export const config: Config = {
-  namespace: 'fa-icon-chooser',
-  outputTargets: [
-    {
-      type: 'www',
-      serviceWorker: null, // disable service workers
-      copy: [{ src: '../dev', dest: 'dev' }],
-    },
-  ],
+  ...baseConfig,
+  outputTargets: baseConfig.outputTargets.map(target => {
+    if (target.type === 'www') {
+      return {
+        ...target,
+        copy: [{ src: join(__dirname, 'dev'), dest: 'dev' }],
+      };
+    }
+    return target;
+  }),
 };


### PR DESCRIPTION
This PR updates the Stencil development configuration by extending the base configuration and adjusting the 'www' output target to correctly reference asset paths in development.

- it imports and uses the base configuration from './stencil.config'
- updates the `outputTargets` array by mapping over targets to adjust the copy path for targets of type 'www'

@mlwilkerson --- can you review for correctness ?