### PR TITLE
update to correct urls

### DIFF
--- a/packages/fa-icon-chooser/dev/runtime.js
+++ b/packages/fa-icon-chooser/dev/runtime.js
@@ -1,7 +1,7 @@
 // This dev-only module isn't processed by the bundler like the others,
 // so we can't use a node env var to set this. Just hardcode it in one
 // place at the top.
-const API_URL = 'https://api-staging.fontawesome.com';
+const API_URL = 'https://api.fontawesome.com';
 
 const FaIconChooserDevExports = (function () {
   let showingIconChooser = false;

--- a/packages/fa-icon-chooser/src/utils/utils.ts
+++ b/packages/fa-icon-chooser/src/utils/utils.ts
@@ -2,9 +2,9 @@ import defaultIconsSearchResultTemplate from './defaultIconsSearchResult.json';
 import { valid as validSemver } from 'semver';
 import { cloneDeep, get, set } from 'lodash';
 
-const FREE_CDN_URL = 'https://use-staging.fontawesome.com';
-const PRO_KIT_ASSET_URL = 'https://ka-p-staging.fontawesome.com';
-const FREE_KIT_ASSET_URL = 'https://ka-f-staging.fontawesome.com';
+const FREE_CDN_URL = 'https://use.fontawesome.com';
+const PRO_KIT_ASSET_URL = 'https://ka-p.fontawesome.com';
+const FREE_KIT_ASSET_URL = 'https://ka-f.fontawesome.com';
 
 export type UrlTextFetcher = (url: string) => Promise<string>;
 


### PR DESCRIPTION
Updates Font Awesome service URLs from staging environment to production environment across the fa-icon-chooser package.

Removes "-staging" suffix from all Font Awesome service URLs (CDN, API, and kit asset URLs).

@mlwilkerson --- you good with the URL changes ?