### PR TITLE
Add React 19 as a peer dependency (unblocking use within Next.js applications)

### DIFF
--- a/packages/fa-icon-chooser-react/package.json
+++ b/packages/fa-icon-chooser-react/package.json
@@ -37,7 +37,7 @@
     "@stencil/react-output-target": "^0.8.2"
   },
   "peerDependencies": {
-    "react": "^17 || ^18",
-    "react-dom": "^17 || ^18"
+    "react": "^17 || ^18 || ^19",
+    "react-dom": "^17 || ^18 || ^19"
   }
 }


### PR DESCRIPTION
Update peer dependency to include React 19 so the package can be used on React 19 projects.