### PR TITLE
Fix includeFamilyStyle filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Thumbs.db
 UserInterfaceState.xcuserstate
 .env
 .npmrc
+.claude/settings.local.json

--- a/packages/fa-icon-chooser/src/components/fa-icon-chooser/fa-icon-chooser.spec.ts
+++ b/packages/fa-icon-chooser/src/components/fa-icon-chooser/fa-icon-chooser.spec.ts
@@ -2,6 +2,7 @@ import { newSpecPage } from '@stencil/core/testing';
 import { FaIconChooser } from './fa-icon-chooser';
 import { buildDefaultIconsSearchResult } from '../../utils/utils';
 import { get } from 'lodash';
+import foodSearchResults from './food-search-results.fixture.json';
 
 // TODO: tests
 // - remove contents from query field after having had some contents: return to default state
@@ -102,5 +103,109 @@ describe('fa-icon-chooser', () => {
           expect(page.root.shadowRoot.innerHTML).toEqual(expect.stringMatching(new RegExp(`<fa-icon .*name="${id}"`)));
         }
       });
+  });
+
+  it('renders icons matching the includeFamilyStyle filter when only "far" is allowed', async () => {
+    const page = await newSpecPage({
+      components: [FaIconChooser],
+    });
+
+    const proHandleQuery = jest.fn((document: string, variables?: any) => {
+      if (document.includes('query KitMetadata')) {
+        return Promise.resolve({
+          data: {
+            me: {
+              kit: {
+                version: '7.0.0',
+                technologySelected: 'svg',
+                licenseSelected: 'pro',
+                name: 'test-kit',
+                permits: {
+                  embedProSvg: [
+                    { prefix: 'fas', family: 'classic' },
+                    { prefix: 'far', family: 'classic' },
+                    { prefix: 'fab', family: 'classic' },
+                  ],
+                },
+                release: {
+                  version: '7.0.0',
+                  familyStyles: [
+                    { family: 'classic', style: 'solid', prefix: 'fas' },
+                    { family: 'classic', style: 'regular', prefix: 'far' },
+                    { family: 'classic', style: 'brands', prefix: 'fab' },
+                    { family: 'classic', style: 'light', prefix: 'fal' },
+                    { family: 'classic', style: 'thin', prefix: 'fat' },
+                    { family: 'duotone', style: 'solid', prefix: 'fad' },
+                    { family: 'sharp', style: 'solid', prefix: 'fass' },
+                    { family: 'sharp', style: 'regular', prefix: 'fasr' },
+                  ],
+                },
+                iconUploads: [],
+              },
+            },
+          },
+        });
+      }
+      if (document.includes('query Search') && variables && variables.query === 'food') {
+        return Promise.resolve({ data: foodSearchResults });
+      }
+      return Promise.resolve({ data: { search: [] } });
+    });
+
+    const getUrlText = jest.fn(url => {
+      if (url.match(/\.js(\?|$)/)) {
+        page.win['FontAwesome'] = {
+          dom: {
+            css: () => '/* fake css */',
+          },
+        };
+        return Promise.resolve('// fake JavaScript');
+      } else {
+        return Promise.reject('fake rejection');
+      }
+    });
+
+    const el = document.createElement('fa-icon-chooser');
+    el.handleQuery = proHandleQuery;
+    el.getUrlText = getUrlText;
+    el.includeFamilyStyle = (familyStyle: { prefix: string }) => familyStyle.prefix === 'far';
+    el.setAttribute('kit-token', 'fake-kit-token');
+
+    // Override slot defaults that share JSX nodes (e.g. <strong> in start-view-detail);
+    // shared JSX nodes can't be re-rendered across tests in the same file under Stencil
+    // testing — providing user content via slots avoids the default JSX entirely.
+    for (const name of ['start-view-detail', 'suggest-icon-upload', 'get-fontawesome-pro']) {
+      const slotEl = document.createElement('span');
+      slotEl.setAttribute('slot', name);
+      slotEl.textContent = `test:${name}`;
+      el.appendChild(slotEl);
+    }
+
+    page.body.appendChild(el);
+    await page.waitForChanges();
+
+    // Sanity check: the only familyStyle that survived the filter should be classic/regular (far).
+    expect(page.rootInstance.familyStyles).toEqual({
+      classic: { regular: { prefix: 'far' } },
+    });
+
+    // Set query state so the empty-query "start view" branch (which renders shared
+    // JSX nodes from slotDefaults) is skipped on re-render. Then run the search,
+    // bypassing the input debounce.
+    page.rootInstance.query = 'food';
+    await page.rootInstance.updateQueryResults('food');
+
+    const filteredIcons = page.rootInstance.filteredIcons();
+
+    // Every icon in the food results that includes {family:"classic", style:"regular"}
+    // in its pro familyStyles list should appear under the 'far' prefix.
+    expect(filteredIcons.length).toBeGreaterThan(0);
+    filteredIcons.forEach(icon => {
+      expect(icon.prefix).toBe('far');
+    });
+
+    const iconNames = filteredIcons.map(i => i.iconName);
+    // These food entries all carry classic/regular in their pro family-styles list.
+    expect(iconNames).toEqual(expect.arrayContaining(['pot-food', 'pan-food', 'can-food', 'bowl-food', 'burger', 'utensils']));
   });
 });

--- a/packages/fa-icon-chooser/src/components/fa-icon-chooser/fa-icon-chooser.tsx
+++ b/packages/fa-icon-chooser/src/components/fa-icon-chooser/fa-icon-chooser.tsx
@@ -390,6 +390,27 @@ export class FaIconChooser {
     }
 
     this.buildFamilyStyleReverseLookup();
+    this.ensureSelectedFamilyStyleIsValid();
+  }
+
+  // Reconciles selectedFamily/selectedStyle with the current familyStyles. The
+  // initial state defaults assume Classic Solid is available, but includeFamilyStyle
+  // (or other filtering) may have removed it; without this, getSelectedPrefix would
+  // return undefined and filteredIcons would render empty even when matches exist.
+  ensureSelectedFamilyStyleIsValid(): void {
+    const families = Object.keys(this.familyStyles).sort();
+    if (families.length === 0) return;
+
+    if (!this.familyStyles[this.selectedFamily]) {
+      this.selectedFamily = families[0];
+    }
+
+    const styles = Object.keys(this.familyStyles[this.selectedFamily] || {}).sort();
+    if (styles.length === 0) return;
+
+    if (!this.familyStyles[this.selectedFamily][this.selectedStyle]) {
+      this.selectedStyle = styles[0];
+    }
   }
 
   resolvedVersion() {

--- a/packages/fa-icon-chooser/src/components/fa-icon-chooser/fa-icon-chooser.tsx
+++ b/packages/fa-icon-chooser/src/components/fa-icon-chooser/fa-icon-chooser.tsx
@@ -395,13 +395,14 @@ export class FaIconChooser {
 
   // Reconciles selectedFamily/selectedStyle with the current familyStyles. The
   // initial state defaults assume Classic Solid is available, but includeFamilyStyle
-  // (or other filtering) may have removed it; without this, getSelectedPrefix would
+  // (or other filtering) may have removed it from the available familyStyles.
+  // Without this, getSelectedPrefix would
   // return undefined and filteredIcons would render empty even when matches exist.
   ensureSelectedFamilyStyleIsValid(): void {
-    const stylesAvailableForSelectedFamily = Object.keys(this.familyStyles[this.selectedFamily] || {});
-    const isCurrentlyValid = stylesAvailableForSelectedFamily.includes(this.selectedStyle);
+    const stylesObjectForSelectedFamily = this.familyStyles[this.selectedFamily] || {};
+    const isSelectedFamilyStyleValid = stylesObjectForSelectedFamily.hasOwnProperty(this.selectedStyle);
 
-    if (isCurrentlyValid) {
+    if (isSelectedFamilyStyleValid) {
       return;
     }
 

--- a/packages/fa-icon-chooser/src/components/fa-icon-chooser/fa-icon-chooser.tsx
+++ b/packages/fa-icon-chooser/src/components/fa-icon-chooser/fa-icon-chooser.tsx
@@ -398,19 +398,20 @@ export class FaIconChooser {
   // (or other filtering) may have removed it; without this, getSelectedPrefix would
   // return undefined and filteredIcons would render empty even when matches exist.
   ensureSelectedFamilyStyleIsValid(): void {
-    const families = Object.keys(this.familyStyles).sort();
-    if (families.length === 0) return;
+    const stylesAvailableForSelectedFamily = Object.keys(this.familyStyles[this.selectedFamily] || {});
+    const isCurrentlyValid = stylesAvailableForSelectedFamily.includes(this.selectedStyle);
 
-    if (!this.familyStyles[this.selectedFamily]) {
-      this.selectedFamily = families[0];
+    if (isCurrentlyValid) {
+      return;
     }
 
-    const styles = Object.keys(this.familyStyles[this.selectedFamily] || {}).sort();
-    if (styles.length === 0) return;
-
-    if (!this.familyStyles[this.selectedFamily][this.selectedStyle]) {
-      this.selectedStyle = styles[0];
-    }
+    const filteredFamilies = Object.keys(this.familyStyles).sort();
+    if (filteredFamilies.length === 0) return;
+    const selectedFamily = filteredFamilies[0];
+    const stylesForSelectedFamily = Object.keys(this.familyStyles[selectedFamily] || {}).sort();
+    if (stylesForSelectedFamily.length === 0) return;
+    this.selectedFamily = selectedFamily;
+    this.selectedStyle = stylesForSelectedFamily[0];
   }
 
   resolvedVersion() {

--- a/packages/fa-icon-chooser/src/components/fa-icon-chooser/food-search-results.fixture.json
+++ b/packages/fa-icon-chooser/src/components/fa-icon-chooser/food-search-results.fixture.json
@@ -1,0 +1,177 @@
+{
+  "search": [
+    {
+      "familyStylesByLicense": {
+        "free": [],
+        "pro": [
+          { "family": "classic", "style": "light" },
+          { "family": "classic", "style": "regular" },
+          { "family": "classic", "style": "solid" },
+          { "family": "classic", "style": "thin" },
+          { "family": "duotone", "style": "light" },
+          { "family": "duotone", "style": "regular" },
+          { "family": "duotone", "style": "solid" },
+          { "family": "duotone", "style": "thin" },
+          { "family": "sharp", "style": "light" },
+          { "family": "sharp", "style": "regular" },
+          { "family": "sharp", "style": "solid" },
+          { "family": "sharp", "style": "thin" },
+          { "family": "sharp-duotone", "style": "light" },
+          { "family": "sharp-duotone", "style": "regular" },
+          { "family": "sharp-duotone", "style": "solid" },
+          { "family": "sharp-duotone", "style": "thin" }
+        ]
+      },
+      "id": "pot-food",
+      "label": "Pot Food"
+    },
+    {
+      "familyStylesByLicense": {
+        "free": [],
+        "pro": [
+          { "family": "classic", "style": "light" },
+          { "family": "classic", "style": "regular" },
+          { "family": "classic", "style": "solid" },
+          { "family": "classic", "style": "thin" },
+          { "family": "duotone", "style": "light" },
+          { "family": "duotone", "style": "regular" },
+          { "family": "duotone", "style": "solid" },
+          { "family": "duotone", "style": "thin" },
+          { "family": "sharp", "style": "light" },
+          { "family": "sharp", "style": "regular" },
+          { "family": "sharp", "style": "solid" },
+          { "family": "sharp", "style": "thin" },
+          { "family": "sharp-duotone", "style": "light" },
+          { "family": "sharp-duotone", "style": "regular" },
+          { "family": "sharp-duotone", "style": "solid" },
+          { "family": "sharp-duotone", "style": "thin" }
+        ]
+      },
+      "id": "pan-food",
+      "label": "Pan Food"
+    },
+    {
+      "familyStylesByLicense": {
+        "free": [],
+        "pro": [
+          { "family": "classic", "style": "light" },
+          { "family": "classic", "style": "regular" },
+          { "family": "classic", "style": "solid" },
+          { "family": "classic", "style": "thin" },
+          { "family": "duotone", "style": "light" },
+          { "family": "duotone", "style": "regular" },
+          { "family": "duotone", "style": "solid" },
+          { "family": "duotone", "style": "thin" },
+          { "family": "sharp", "style": "light" },
+          { "family": "sharp", "style": "regular" },
+          { "family": "sharp", "style": "solid" },
+          { "family": "sharp", "style": "thin" },
+          { "family": "sharp-duotone", "style": "light" },
+          { "family": "sharp-duotone", "style": "regular" },
+          { "family": "sharp-duotone", "style": "solid" },
+          { "family": "sharp-duotone", "style": "thin" }
+        ]
+      },
+      "id": "can-food",
+      "label": "Can Food"
+    },
+    {
+      "familyStylesByLicense": {
+        "free": [{ "family": "classic", "style": "solid" }],
+        "pro": [
+          { "family": "classic", "style": "light" },
+          { "family": "classic", "style": "regular" },
+          { "family": "classic", "style": "solid" },
+          { "family": "classic", "style": "thin" },
+          { "family": "duotone", "style": "light" },
+          { "family": "duotone", "style": "regular" },
+          { "family": "duotone", "style": "solid" },
+          { "family": "duotone", "style": "thin" },
+          { "family": "sharp", "style": "light" },
+          { "family": "sharp", "style": "regular" },
+          { "family": "sharp", "style": "solid" },
+          { "family": "sharp", "style": "thin" },
+          { "family": "sharp-duotone", "style": "light" },
+          { "family": "sharp-duotone", "style": "regular" },
+          { "family": "sharp-duotone", "style": "solid" },
+          { "family": "sharp-duotone", "style": "thin" }
+        ]
+      },
+      "id": "bowl-food",
+      "label": "Bowl Food"
+    },
+    {
+      "familyStylesByLicense": {
+        "free": [{ "family": "classic", "style": "brands" }],
+        "pro": [{ "family": "classic", "style": "brands" }]
+      },
+      "id": "nutritionix",
+      "label": "Nutritionix"
+    },
+    {
+      "familyStylesByLicense": {
+        "free": [{ "family": "classic", "style": "solid" }],
+        "pro": [
+          { "family": "classic", "style": "light" },
+          { "family": "classic", "style": "regular" },
+          { "family": "classic", "style": "solid" },
+          { "family": "classic", "style": "thin" },
+          { "family": "duotone", "style": "light" },
+          { "family": "duotone", "style": "regular" },
+          { "family": "duotone", "style": "solid" },
+          { "family": "duotone", "style": "thin" },
+          { "family": "sharp", "style": "light" },
+          { "family": "sharp", "style": "regular" },
+          { "family": "sharp", "style": "solid" },
+          { "family": "sharp", "style": "thin" },
+          { "family": "sharp-duotone", "style": "light" },
+          { "family": "sharp-duotone", "style": "regular" },
+          { "family": "sharp-duotone", "style": "solid" },
+          { "family": "sharp-duotone", "style": "thin" }
+        ]
+      },
+      "id": "burger",
+      "label": "Burger"
+    },
+    {
+      "familyStylesByLicense": {
+        "free": [{ "family": "classic", "style": "solid" }],
+        "pro": [
+          { "family": "chisel", "style": "regular" },
+          { "family": "classic", "style": "light" },
+          { "family": "classic", "style": "regular" },
+          { "family": "classic", "style": "solid" },
+          { "family": "classic", "style": "thin" },
+          { "family": "duotone", "style": "light" },
+          { "family": "duotone", "style": "regular" },
+          { "family": "duotone", "style": "solid" },
+          { "family": "duotone", "style": "thin" },
+          { "family": "etch", "style": "solid" },
+          { "family": "graphite", "style": "thin" },
+          { "family": "jelly", "style": "regular" },
+          { "family": "jelly-duo", "style": "regular" },
+          { "family": "jelly-fill", "style": "regular" },
+          { "family": "notdog", "style": "solid" },
+          { "family": "notdog-duo", "style": "solid" },
+          { "family": "sharp", "style": "light" },
+          { "family": "sharp", "style": "regular" },
+          { "family": "sharp", "style": "solid" },
+          { "family": "sharp", "style": "thin" },
+          { "family": "sharp-duotone", "style": "light" },
+          { "family": "sharp-duotone", "style": "regular" },
+          { "family": "sharp-duotone", "style": "solid" },
+          { "family": "sharp-duotone", "style": "thin" },
+          { "family": "slab", "style": "regular" },
+          { "family": "slab-press", "style": "regular" },
+          { "family": "thumbprint", "style": "light" },
+          { "family": "utility", "style": "semibold" },
+          { "family": "utility-duo", "style": "semibold" },
+          { "family": "utility-fill", "style": "semibold" },
+          { "family": "whiteboard", "style": "semibold" }
+        ]
+      },
+      "id": "utensils",
+      "label": "Utensils"
+    }
+  ]
+}


### PR DESCRIPTION
The initial implementation of the `includeFamilyStyle` filter in #66 did not account for the possibility that the filter may exclude the familyStyle that is one currently selected by `this.selectedFamily` and `this.selectedStyle`.

For example, by default, Classic Solid is selected. But if the `includeFamilyStyle` filter is used to restrict to only Classic Regular, then it will zero matching search results.

This fixes that bug by ensuring that whenever the available familyStyles are updated, if the currently selected familyStyle is not among the available familyStyles, then the selected familyStyle is automatically updated and set to the first available familyStyle.